### PR TITLE
Add Policy and Insurer entities with CRUD operations

### DIFF
--- a/InsuranceHub/src/main/java/com/example/insurance/controllers/InsurerController.java
+++ b/InsuranceHub/src/main/java/com/example/insurance/controllers/InsurerController.java
@@ -1,0 +1,46 @@
+package com.example.insurance.controllers;
+
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import com.example.insurance.entities.Insurer;
+import com.example.insurance.services.InsurerService;
+
+import java.util.List;
+import java.util.Optional;
+
+@RestController
+@RequestMapping("/api/insurers")
+public class InsurerController {
+    @Autowired
+    private InsurerService insurerService;
+
+    @GetMapping
+    public List<Insurer> getAllInsurers() {
+        return insurerService.getAllInsurers();
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<Insurer> getInsurerById(@PathVariable Integer id) {
+        Optional<Insurer> insurer = insurerService.getInsurerById(id);
+        return insurer.map(ResponseEntity::ok).orElseGet(() -> ResponseEntity.notFound().build());
+    }
+
+    @PostMapping
+    public ResponseEntity<Insurer> createInsurer(@RequestBody Insurer insurer) {
+        return ResponseEntity.ok(insurerService.createInsurer(insurer));
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<Insurer> updateInsurer(@PathVariable Integer id, @RequestBody Insurer updatedInsurer) {
+        Insurer insurer = insurerService.updateInsurer(id, updatedInsurer);
+        return insurer != null ? ResponseEntity.ok(insurer) : ResponseEntity.notFound().build();
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deleteInsurer(@PathVariable Integer id) {
+        return insurerService.deleteInsurer(id) ? ResponseEntity.noContent().build() : ResponseEntity.notFound().build();
+    }
+}

--- a/InsuranceHub/src/main/java/com/example/insurance/controllers/PolicyController.java
+++ b/InsuranceHub/src/main/java/com/example/insurance/controllers/PolicyController.java
@@ -1,0 +1,50 @@
+package com.example.insurance.controllers;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import com.example.insurance.entities.Policy;
+import com.example.insurance.services.PolicyService;
+
+import java.util.List;
+import java.util.Optional;
+
+@RestController
+@RequestMapping("/api/policies")
+public class PolicyController {
+    @Autowired
+    private PolicyService policyService;
+
+    @GetMapping
+    public ResponseEntity<List<Policy>> getAllPolicies() {
+        List<Policy> policies = policyService.getAllPolicies();
+        if (policies.isEmpty()) {
+            return ResponseEntity.noContent().build();  // 204 No Content if empty
+        }
+        return ResponseEntity.ok(policies);
+        
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<Policy> getPolicyById(@PathVariable Integer id) {
+        Optional<Policy> policy = policyService.getPolicyById(id);
+        return policy.map(ResponseEntity::ok).orElseGet(() -> ResponseEntity.notFound().build());
+    }
+
+    @PostMapping
+    public ResponseEntity<Policy> createPolicy(@RequestBody Policy policy) {
+        return ResponseEntity.ok(policyService.createPolicy(policy));
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<Policy> updatePolicy(@PathVariable Integer id, @RequestBody Policy updatedPolicy) {
+        Policy policy = policyService.updatePolicy(id, updatedPolicy);
+        return policy != null ? ResponseEntity.ok(policy) : ResponseEntity.notFound().build();
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deletePolicy(@PathVariable Integer id) {
+        return policyService.deletePolicy(id) ? ResponseEntity.noContent().build() : ResponseEntity.notFound().build();
+    }
+}

--- a/InsuranceHub/src/main/java/com/example/insurance/entities/Insurer.java
+++ b/InsuranceHub/src/main/java/com/example/insurance/entities/Insurer.java
@@ -1,0 +1,83 @@
+package com.example.insurance.entities;
+
+import jakarta.persistence.*;
+
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonManagedReference;
+
+@Entity
+@Table(name = "insurer")
+@JsonIgnoreProperties({"hibernateLazyInitializer", "handler"})  // Prevents Lazy Initialization issues
+
+public class Insurer {
+    
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "I_ID")  
+    private Integer id;  
+
+    @Column(name = "I_name", nullable = false)
+    private String name;  
+
+    @Column(name = "LicenseNO", nullable = false, unique = true)
+    private String licenseNo;  
+
+    @OneToOne(fetch = FetchType.LAZY)  
+    @JoinColumn(name = "UID", nullable = false)
+    @JsonIgnore  // 👈 Prevents serialization issues with User
+    private User user;
+
+    @OneToMany(mappedBy = "insurer", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    @JsonManagedReference
+    // 👈 Prevents infinite loop
+    @JsonIgnore 
+    private List<Policy> policies;
+
+
+	public Integer getId() {
+		return id;
+	}
+
+	public void setId(Integer id) {
+		this.id = id;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	public String getLicenseNo() {
+		return licenseNo;
+	}
+
+	public void setLicenseNo(String licenseNo) {
+		this.licenseNo = licenseNo;
+	}
+
+	public User getUser() {
+		return user;
+	}
+
+	public void setUser(User user) {
+		this.user = user;
+	}
+
+	public List<Policy> getPolicies() {
+		return policies;
+	}
+
+	public void setPolicies(List<Policy> policies) {
+		this.policies = policies;
+	}
+
+	
+
+}

--- a/InsuranceHub/src/main/java/com/example/insurance/entities/Policy.java
+++ b/InsuranceHub/src/main/java/com/example/insurance/entities/Policy.java
@@ -1,0 +1,73 @@
+package com.example.insurance.entities;
+
+
+import com.fasterxml.jackson.annotation.JsonBackReference;
+
+import jakarta.persistence.*;
+
+
+@Entity
+
+@Table(name = "policy")
+
+public class Policy {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer PolicyID;
+
+    @Column(nullable = false)
+    private String P_name;
+
+    @Column(nullable = false)
+    private String Premium;
+
+    @Column(nullable = false)
+    private String Terms;
+
+    @ManyToOne
+    @JoinColumn(name = "I_ID", nullable = false)
+    @JsonBackReference
+    private Insurer insurer;
+
+	public Integer getPolicyID() {
+		return PolicyID;
+	}
+
+	public void setPolicyID(Integer policyID) {
+		PolicyID = policyID;
+	}
+
+	public String getP_name() {
+		return P_name;
+	}
+
+	public void setP_name(String p_name) {
+		P_name = p_name;
+	}
+
+	public String getPremium() {
+		return Premium;
+	}
+
+	public void setPremium(String premium) {
+		Premium = premium;
+	}
+
+	public String getTerms() {
+		return Terms;
+	}
+
+	public void setTerms(String terms) {
+		Terms = terms;
+	}
+
+	public Insurer getInsurer() {
+		return insurer;
+	}
+
+	public void setInsurer(Insurer insurer) {
+		this.insurer = insurer;
+	}
+
+	
+}

--- a/InsuranceHub/src/main/java/com/example/insurance/entities/User.java
+++ b/InsuranceHub/src/main/java/com/example/insurance/entities/User.java
@@ -14,7 +14,7 @@ public class User {
 
 	    @Id
 	    @GeneratedValue(strategy = GenerationType.IDENTITY)
-	    private Long uid;
+	    private Integer uid;
 
 	    @Column(nullable = false)
 	    private String uname;
@@ -32,11 +32,11 @@ public class User {
 	    private String address;  // Added the address field
 
 	    // Getters and Setters
-	    public Long getUid() {
+	    public Integer getUid() {
 	        return uid;
 	    }
 
-	    public void setUid(Long uid) {
+	    public void setUid(Integer uid) {
 	        this.uid = uid;
 	    }
 

--- a/InsuranceHub/src/main/java/com/example/insurance/repositories/InsurerRepository.java
+++ b/InsuranceHub/src/main/java/com/example/insurance/repositories/InsurerRepository.java
@@ -1,0 +1,11 @@
+package com.example.insurance.repositories;
+
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.example.insurance.entities.Insurer;
+
+@Repository
+public interface InsurerRepository extends JpaRepository<Insurer, Integer> {
+}

--- a/InsuranceHub/src/main/java/com/example/insurance/repositories/PolicyRepository.java
+++ b/InsuranceHub/src/main/java/com/example/insurance/repositories/PolicyRepository.java
@@ -1,0 +1,12 @@
+package com.example.insurance.repositories;
+
+
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.example.insurance.entities.Policy;
+
+@Repository
+public interface PolicyRepository extends JpaRepository<Policy, Integer> {
+}

--- a/InsuranceHub/src/main/java/com/example/insurance/services/InsurerService.java
+++ b/InsuranceHub/src/main/java/com/example/insurance/services/InsurerService.java
@@ -1,0 +1,45 @@
+package com.example.insurance.services;
+
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import com.example.insurance.entities.Insurer;
+import com.example.insurance.repositories.InsurerRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+public class InsurerService {
+    @Autowired
+    private InsurerRepository insurerRepository;
+
+    public List<Insurer> getAllInsurers() {
+        return insurerRepository.findAll();
+    }
+
+    public Optional<Insurer> getInsurerById(Integer id) {
+        return insurerRepository.findById(id);
+    }
+
+    public Insurer createInsurer(Insurer insurer) {
+        return insurerRepository.save(insurer);
+    }
+
+    public Insurer updateInsurer(Integer id, Insurer updatedInsurer) {
+        if (insurerRepository.existsById(id)) {
+            updatedInsurer.setId(id);
+            return insurerRepository.save(updatedInsurer);
+        }
+        return null;
+    }
+
+    public boolean deleteInsurer(Integer id) {
+        if (insurerRepository.existsById(id)) {
+            insurerRepository.deleteById(id);
+            return true;
+        }
+        return false;
+    }
+}

--- a/InsuranceHub/src/main/java/com/example/insurance/services/PolicyService.java
+++ b/InsuranceHub/src/main/java/com/example/insurance/services/PolicyService.java
@@ -1,0 +1,52 @@
+package com.example.insurance.services;
+
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import com.example.insurance.entities.Policy;
+import com.example.insurance.repositories.PolicyRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+public class PolicyService {
+    @Autowired
+    private PolicyRepository policyRepository;
+//
+//    public List<Policy> getAllPolicies() {
+//        return policyRepository.findAll();
+//    }
+
+    public List<Policy> getAllPolicies() {
+        List<Policy> policies = policyRepository.findAll();
+        System.out.println("Fetched policies: " + policies);  // Debugging line to print policies
+        return policies;
+    }
+
+    
+    public Optional<Policy> getPolicyById(Integer id) {
+        return policyRepository.findById(id);
+    }
+
+    public Policy createPolicy(Policy policy) {
+        return policyRepository.save(policy);
+    }
+
+    public Policy updatePolicy(Integer id, Policy updatedPolicy) {
+        if (policyRepository.existsById(id)) {
+            updatedPolicy.setPolicyID(id);
+            return policyRepository.save(updatedPolicy);
+        }
+        return null;
+    }
+
+    public boolean deletePolicy(Integer id) {
+        if (policyRepository.existsById(id)) {
+            policyRepository.deleteById(id);
+            return true;
+        }
+        return false;
+    }
+}


### PR DESCRIPTION
- Created Policy and Insurer entities with JPA annotations
- Implemented basic CRUD operations for Policy and Insurer in Spring Boot REST API
- Configured repository and service layers for database interactions
- Tested endpoints for creating, updating, retrieving, and deleting records